### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -11,6 +11,8 @@
 # For more information about SLSA and how it improves the supply-chain, visit slsa.dev.
 
 name: SLSA generic generator
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/JaclynCodes/Pretend-telegram/security/code-scanning/1](https://github.com/JaclynCodes/Pretend-telegram/security/code-scanning/1)

To fix the problem, an explicit minimal `permissions` block should be added to the workflow so that the `GITHUB_TOKEN` is limited to only the permissions required. As the `build` job does not interact with repository contents in any write capacity, nor does it seem to need to write to any other GitHub areas, the most restrictive and recommended setting (`contents: read`) should be used. This can be set at the workflow root (applying to all jobs that don't override it), or specifically for the `build` job alone. In this situation, the cleanest fix would be to add a `permissions:` block at the root level, just after `name:` and `on:` (e.g., after line 13), like so: 
```yaml
permissions:
  contents: read
```
This will improve security by ensuring that unneeded write permissions are not available to jobs in the workflow unless explicitly specified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
